### PR TITLE
Remove call to etap:diag function

### DIFF
--- a/apps/couch/src/couch_compaction_daemon.erl
+++ b/apps/couch/src/couch_compaction_daemon.erl
@@ -130,8 +130,6 @@ compact_loop(Parent) ->
 
 
 maybe_compact_db(DbName, Config) ->
-    etap:diag("~n~n~n~n################~nCOMPACTING: ~p~n#############~n~n",
-        [DbName]),
     case (catch couch_db:open_int(DbName, [{user_ctx, #user_ctx{roles=[<<"_admin">>]}}])) of
     {ok, Db} ->
         DDocNames = db_ddoc_names(Db),


### PR DESCRIPTION
It fixes crash during automatic db compaction.

```
{compaction_loop_died,{undef,[{etap,diag,["~n~n~n~n################~nCOMPACTING: ~p~n#############~...
```
